### PR TITLE
Added colours and styles to the Sublime version, updated Sublime version README (PHP-focus)

### DIFF
--- a/sublime-text/README.md
+++ b/sublime-text/README.md
@@ -3,6 +3,11 @@ Sublime Text Color Scheme
 
 ![Screenshot](http://puu.sh/cNJrg/177f23398e.png)
 
+## To Do
+
+* Figure out why `variable` (:120) is overriding the more specific `meta.function.arguments.php` (:50)
+  * fix it
+
 ## How To Install
 
 ### [Download](https://raw.githubusercontent.com/Ultrabenosaurus/colour-scheme/master/sublime-text/moldcraft.tmTheme) the file

--- a/sublime-text/README.md
+++ b/sublime-text/README.md
@@ -1,11 +1,11 @@
 Sublime Text Color Scheme
 ===
 
-![Screenshot](screenshot.png)
+![Screenshot](http://puu.sh/cNJrg/177f23398e.png)
 
 ## How To Install
 
-### [Download](moldcraft.tmTheme) the file
+### [Download](https://raw.githubusercontent.com/Ultrabenosaurus/colour-scheme/master/sublime-text/moldcraft.tmTheme) the file
 
 ### Copy the file to directory
 

--- a/sublime-text/moldcraft.tmTheme
+++ b/sublime-text/moldcraft.tmTheme
@@ -45,6 +45,19 @@ Find more at : https://github.com/moldcraft/colour-scheme
         </dict>
         <dict>
             <key>name</key>
+            <string>Function Variable</string>
+            <key>scope</key>
+            <string>meta.function.arguments.php</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#f4dc6e</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
             <string>Comment</string>
             <key>scope</key>
             <string>comment</string>
@@ -96,6 +109,8 @@ Find more at : https://github.com/moldcraft/colour-scheme
             <dict>
                 <key>foreground</key>
                 <string>#446cff</string>
+                <key>fontStyle</key>
+                <string>italic bold</string>
             </dict>
         </dict>
         <dict>
@@ -131,6 +146,8 @@ Find more at : https://github.com/moldcraft/colour-scheme
             <dict>
                 <key>fontStyle</key>
                 <string></string>
+                <key>foreground</key>
+                <string>#ff8019</string>
             </dict>
         </dict>
         <dict>
@@ -181,6 +198,32 @@ Find more at : https://github.com/moldcraft/colour-scheme
         </dict>
         <dict>
             <key>name</key>
+            <string>Object Function Call</string>
+            <key>scope</key>
+            <string>meta.function-call.object.php</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#f4dc6e</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Object Function Call</string>
+            <key>scope</key>
+            <string>meta.function-call.static.php</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#f4dc6e</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
             <string>Tag name</string>
             <key>scope</key>
             <string>entity.name.tag</string>
@@ -213,7 +256,9 @@ Find more at : https://github.com/moldcraft/colour-scheme
             <key>settings</key>
             <dict>
                 <key>fontStyle</key>
-                <string></string>
+                <string>italic</string>
+                <key>foreground</key>
+                <string>#D19A48</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
As noted in my addition to the README, I need to figure out why the `variable` scope (:120) is overriding the more specific `meta.function.arguments.php` scope (:50) to get parameter highlighting different to local variables.

Other than that, and an extra italic on class instantiations because I wanted to, this is almost identical to phpStorm's version. At least for PHP.
